### PR TITLE
add support for restoring training and disable variable initialization info

### DIFF
--- a/promise2012/Vnet/model_vnet3d.py
+++ b/promise2012/Vnet/model_vnet3d.py
@@ -234,7 +234,7 @@ class Vnet3dModule(object):
         tf.summary.scalar("loss", self.cost)
         tf.summary.scalar("accuracy", self.accuracy)
         merged_summary_op = tf.summary.merge_all()
-        sess = tf.InteractiveSession(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=True))
+        sess = tf.InteractiveSession(config=tf.ConfigProto(allow_soft_placement=True, log_device_placement=False))
         summary_writer = tf.summary.FileWriter(logs_path, graph=tf.get_default_graph())
         sess.run(init)
 

--- a/promise2012/Vnet/model_vnet3d.py
+++ b/promise2012/Vnet/model_vnet3d.py
@@ -211,7 +211,7 @@ class Vnet3dModule(object):
             self.sess.run(init)
             saver.restore(self.sess, model_path)
         else:
-          self.restore_training(model_path)
+            self.restore_training(model_path)
 
     def __get_cost(self, cost_name):
         Z, H, W, C = self.Y_gt.get_shape().as_list()[1:]

--- a/promise2012/Vnet/model_vnet3d.py
+++ b/promise2012/Vnet/model_vnet3d.py
@@ -210,6 +210,8 @@ class Vnet3dModule(object):
             self.sess = tf.InteractiveSession()
             self.sess.run(init)
             saver.restore(self.sess, model_path)
+        else:
+          self.restore_training(model_path)
 
     def __get_cost(self, cost_name):
         Z, H, W, C = self.Y_gt.get_shape().as_list()[1:]
@@ -320,3 +322,18 @@ class Vnet3dModule(object):
         result = np.clip(result, 0, 255).astype('uint8')
         result = np.reshape(result, (test_images.shape[0], test_images.shape[1], test_images.shape[2]))
         return result
+      
+    def restore_training(self, model_path):
+        print("\nReading checkpoints...")
+
+        ckpt = tf.train.get_checkpoint_state(model_path)
+        if ckpt and ckpt.model_checkpoint_path:
+            init = tf.global_variables_initializer()
+            saver = tf.train.Saver()
+            self.sess = tf.Session()
+            self.sess.run(init)
+            saver.restore(self.sess, ckpt.model_checkpoint_path)
+            print('Loading success, global training epoch is %s' % (len(ckpt.all_model_checkpoint_paths)-1))
+        else:
+            print('No checkpoint file found.')
+            return

--- a/promise2012/Vnet/model_vnet3d.py
+++ b/promise2012/Vnet/model_vnet3d.py
@@ -204,14 +204,14 @@ class Vnet3dModule(object):
                                        self.phase, self.drop)
         self.cost = self.__get_cost(costname)
         self.accuracy = -self.__get_cost(costname)
+        self.global_epoch = 0
+
         if inference:
-            init = tf.global_variables_initializer()
-            saver = tf.train.Saver()
-            self.sess = tf.InteractiveSession()
-            self.sess.run(init)
-            saver.restore(self.sess, model_path)
+            self.restore_training_2(model_path)
         else:
-            self.restore_training(model_path)
+            n_epoch = self.restore_training_2(model_path)
+            if n_epoch:
+                self.global_epoch = self.global_epoch + n_epoch
 
     def __get_cost(self, cost_name):
         Z, H, W, C = self.Y_gt.get_shape().as_list()[1:]
@@ -229,7 +229,7 @@ class Vnet3dModule(object):
         train_op = tf.train.AdamOptimizer(self.lr).minimize(self.cost)
 
         init = tf.global_variables_initializer()
-        saver = tf.train.Saver(tf.all_variables(), max_to_keep=10)
+        saver = tf.train.Saver(max_to_keep=2)
 
         tf.summary.scalar("loss", self.cost)
         tf.summary.scalar("accuracy", self.accuracy)
@@ -292,7 +292,7 @@ class Vnet3dModule(object):
                 result = result.astype(np.float32)
                 save_images(result, [8, 8], path='img/Vnet/' + 'predict_%d_epoch.png' % (i))
 
-                save_path = saver.save(sess, model_path, global_step=i)
+                save_path = saver.save(sess, model_path, global_step=self.global_epoch+i+1)
                 print("Model saved in file:", save_path)
                 if i % (DISPLAY_STEP * 10) == 0 and i:
                     DISPLAY_STEP *= 10
@@ -306,8 +306,6 @@ class Vnet3dModule(object):
             summary_writer.add_summary(summary, i)
         summary_writer.close()
 
-        save_path = saver.save(sess, model_path)
-        print("Model saved in file:", save_path)
 
     def prediction(self, test_images):
         test_images = np.reshape(test_images, (test_images.shape[0], test_images.shape[1], test_images.shape[2], 1))
@@ -323,7 +321,7 @@ class Vnet3dModule(object):
         result = np.reshape(result, (test_images.shape[0], test_images.shape[1], test_images.shape[2]))
         return result
       
-    def restore_training(self, model_path):
+    def restore_training_2(self, model_path):
         print("\nReading checkpoints...")
 
         ckpt = tf.train.get_checkpoint_state(model_path)
@@ -332,8 +330,13 @@ class Vnet3dModule(object):
             saver = tf.train.Saver()
             self.sess = tf.Session()
             self.sess.run(init)
+
+            print('Checkpoint file: {}'.format(ckpt.model_checkpoint_path))
             saver.restore(self.sess, ckpt.model_checkpoint_path)
-            print('Loading success, global training epoch is %s' % (len(ckpt.all_model_checkpoint_paths)-1))
+            n_epoch = int(ckpt.model_checkpoint_path.split('/')[-1].split('-')[-1])
+
+            print('Loading success, global training epoch is: {}\n'.format(n_epoch))
+            return n_epoch
         else:
-            print('No checkpoint file found.')
+            print('No checkpoint file found.\n')
             return

--- a/promise2012/vnet3d_train_predict.py
+++ b/promise2012/vnet3d_train_predict.py
@@ -3,6 +3,8 @@ from promise2012.Vnet.util import convertMetaModelToPbModel
 import numpy as np
 import pandas as pd
 import cv2
+import tensorflow as tf
+tf.logging.set_verbosity(tf.logging.ERROR)
 
 
 def train():
@@ -20,8 +22,8 @@ def train():
     imagedata = imagedata[perm]
     maskdata = maskdata[perm]
 
-    Vnet3d = Vnet3dModule(128, 128, 64, channels=1, costname="dice coefficient")
-    Vnet3d.train(imagedata, maskdata, "model\\Vnet3dModule.pd", "log\\", 0.001, 0.7, 100000, 1)
+    Vnet3d = Vnet3dModule(128, 128, 64, channels=1, costname="dice coefficient", model_path="model")
+    Vnet3d.train(imagedata, maskdata, "model\\my_model", "log\\", 0.001, 0.7, 100000, 1)
 
 
 def predict0():


### PR DESCRIPTION
1. add support for restoring training. Reasoning is that training process might take very long time, and if will be very beneficial if we can resume previous training.
2. disable variable initialization info. The variable initialization info is pretty messy, better to disable it. 